### PR TITLE
fix excludes

### DIFF
--- a/command.js
+++ b/command.js
@@ -73,8 +73,8 @@ module.exports = function(pluginOptions) {
                                         };
                                     })
                                     .filter(function(rect) {
-                                        return rect.x > 0 && (rect.x + rect.width) < screenshotSize.width &&
-                                            rect.y > 0 && (rect.y + rect.height) < screenshotSize.height;
+                                        return rect.x >= 0 && (rect.x + rect.width) < screenshotSize.width &&
+                                            rect.y >= 0 && (rect.y + rect.height) < screenshotSize.height;
                                     })
                                     .map(function(rect) {
                                         return screenshot.fill(rect.x, rect.y, rect.width, rect.height, rect.color);


### PR DESCRIPTION
Hi @sergets 

I encountered a problem where when I try to exclude a selector with x-coordinate equal to 0, the element isn’t excluded when screenshots are checked.

So, I made a minor correction in the filter method.